### PR TITLE
Update swig and wxWidgets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ environment:
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_73_0\lib64-msvc-14.2
     PYTHON_LIBRARY: C:\Python38-x64\libs\python38.lib
     PYTHON_INCLUDE_DIR: C:\Python38-x64\include
-    WXWIN: C:\wxWidgets-3.1.4\
-    wxWidgets_ROOT_DIR: C:\wxWidgets-3.1.4\
-    wxWidgets_INCLUDE_DIRS: C:\wxWidgets-3.1.4\include
-    wxWidgets_LIBRARIES: C:\wxWidgets-3.1.4\lib\vc14x_x64_dll
+    WXWIN: C:\wxWidgets-3.1.5\
+    wxWidgets_ROOT_DIR: C:\wxWidgets-3.1.5\
+    wxWidgets_INCLUDE_DIRS: C:\wxWidgets-3.1.5\include
+    wxWidgets_LIBRARIES: C:\wxWidgets-3.1.5\lib\vc14x_x64_dll
     SWIG_DIR: C:\ProgramData\chocolatey\lib\swig\tools
     #SWIG_EXECUTABLE: C:\Libraries\swigwin-3.0.11\swig.exe
     PYTHON_EXECUTABLE: C:\Python38-x64\python.exe
@@ -50,14 +50,14 @@ before_build:
   # Copy x64 dll from system32 to python27 x64
   #- cmd: copy c:\windows\system32\PYTHON27.DLL C:\Python27-x64\python27.dll
   - echo Download wxWidgets lib
-  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.7z'
-  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxMSW-3.1.4_vc14x_x64_Dev.7z'
-  - cmd: 7z x -aoa wxWidgets-3.1.4.7z -oC:\wxWidgets-3.1.4
-  - cmd: 7z x -aoa wxMSW-3.1.4_vc14x_x64_Dev.7z -oC:\wxWidgets-3.1.4
+  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.7z'
+  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxMSW-3.1.5_vc14x_x64_Dev.7z'
+  - cmd: 7z x -aoa wxWidgets-3.1.5.7z -oC:\wxWidgets-3.1.5
+  - cmd: 7z x -aoa wxMSW-3.1.5_vc14x_x64_Dev.7z -oC:\wxWidgets-3.1.5
   - cmd: dir %wxWidgets_LIBRARIES%
   # Download Release wxWidgets DLL's
-  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxMSW-3.1.4_vc14x_x64_ReleaseDLL.7z' -Timeout 15000
-  - cmd: 7z x -aoa wxMSW-3.1.4_vc14x_x64_ReleaseDLL.7z -oC:\wxWidgets-3.1.4
+  - ps: Start-FileDownload 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxMSW-3.1.5_vc14x_x64_ReleaseDLL.7z' -Timeout 15000
+  - cmd: 7z x -aoa wxMSW-3.1.5_vc14x_x64_ReleaseDLL.7z -oC:\wxWidgets-3.1.5
   # install dependencies:
   - choco install poedit nsis 7zip.install
   #- ps: Start-FileDownload 'https://github.com/nicolas-f/build_resources/raw/master/swigwin-3.0.11.zip' -FileName 'c:\Libraries\swigwin-3.0.11.zip' -Timeout 15000

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ environment:
     wxWidgets_ROOT_DIR: C:\wxWidgets-3.1.4\
     wxWidgets_INCLUDE_DIRS: C:\wxWidgets-3.1.4\include
     wxWidgets_LIBRARIES: C:\wxWidgets-3.1.4\lib\vc14x_x64_dll
-    SWIG_DIR: C:\Libraries\swigwin-3.0.11
-    SWIG_EXECUTABLE: C:\Libraries\swigwin-3.0.11\swig.exe
+    SWIG_DIR: C:\ProgramData\chocolatey\lib\swig\tools
+    #SWIG_EXECUTABLE: C:\Libraries\swigwin-3.0.11\swig.exe
     PYTHON_EXECUTABLE: C:\Python38-x64\python.exe
     CTEST_OUTPUT_ON_FAILURE: 1
 
@@ -60,8 +60,9 @@ before_build:
   - cmd: 7z x -aoa wxMSW-3.1.4_vc14x_x64_ReleaseDLL.7z -oC:\wxWidgets-3.1.4
   # install dependencies:
   - choco install poedit nsis 7zip.install
-  - ps: Start-FileDownload 'https://github.com/nicolas-f/build_resources/raw/master/swigwin-3.0.11.zip' -FileName 'c:\Libraries\swigwin-3.0.11.zip' -Timeout 15000
-  - ps: 7z x -aoa c:\Libraries\swigwin-3.0.11.zip -oC:\Libraries -r -y
+  #- ps: Start-FileDownload 'https://github.com/nicolas-f/build_resources/raw/master/swigwin-3.0.11.zip' -FileName 'c:\Libraries\swigwin-3.0.11.zip' -Timeout 15000
+  #- ps: 7z x c:\Libraries\swigwin-3.0.11.zip -oC:\Libraries -r -y
+  - choco install swig
   - cmd: SET PATH=%PATH%;%WXWIN%;%SWIG_DIR%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;%BOOST_LIBRARYDIR%;
   - ps: swig.exe -version
   - echo Running cmake...

--- a/src/isimpa/CMakeLists.txt
+++ b/src/isimpa/CMakeLists.txt
@@ -524,6 +524,7 @@ if(WIN32) # Check if we are on Windows
     set(DIRS ${Boost_LIBRARY_DIR_DEBUG}
              ${Boost_LIBRARY_DIR_RELEASE}
              ${wxWidgets_LIB_DIR_SLASH}
+             ${PYTHON_ROOT_FOLDER}
     )
 
     install(CODE "

--- a/src/isimpa/IHM/simpleGraph.cpp
+++ b/src/isimpa/IHM/simpleGraph.cpp
@@ -1072,7 +1072,7 @@ namespace sgSpace
 		wxPen oldPen = currentElementStyle->GetPen();
 		wxPen newPen = oldPen;
 		newPen.SetWidth(1);
-		newPen.SetStyle(wxSOLID);
+		newPen.SetStyle(wxPENSTYLE_SOLID);
 		currentContext->SetPen(newPen);
 
 
@@ -1170,9 +1170,9 @@ namespace sgSpace
 	}
 	void SG_Renderer::DrawRectangle(const wxRect& rectArea)
 	{
-		if (currentElementStyle->GetBrush().GetStyle() != wxTRANSPARENT)
+		if (currentElementStyle->GetBrush().GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
 		{
-			currentContext->SetBrush(wxBrush(currentElementStyle->GetPen().GetColour(), wxSOLID));
+			currentContext->SetBrush(wxBrush(currentElementStyle->GetPen().GetColour(), wxBRUSHSTYLE_SOLID));
 			currentContext->DrawRectangle(rectArea);
 		}
 		//Dessin du rect de style
@@ -1282,7 +1282,7 @@ namespace sgSpace
 		backingStoreDc(NULL)
 	{
 		InheritAttributes();
-		wxPen pen = wxPen(*wxBLACK, 1, wxDOT);
+		wxPen pen = wxPen(*wxBLACK, 1, wxPENSTYLE_DOT);
 		zoomAreaHintStyle.SetPen(&pen);
 		zoomAreaHintStyle.SetBrush(wxTRANSPARENT_BRUSH);
 	}

--- a/src/isimpa/IHM/simpleGraphEnumerators.cpp
+++ b/src/isimpa/IHM/simpleGraphEnumerators.cpp
@@ -60,27 +60,27 @@ namespace sgSpace
 	}
 	void SG_EnumeratorFiller::FillPenStyleEnumeration(StyleArray& arrayToFeed)
 	{
-		arrayToFeed.Add(t_LstEnums(_("Transparent"),wxTRANSPARENT));
-		arrayToFeed.Add(t_LstEnums(_("Continuous line"),wxSOLID));
-		arrayToFeed.Add(t_LstEnums(_("Point"),wxDOT));
-		arrayToFeed.Add(t_LstEnums(_("Left diagonal dash"),wxBDIAGONAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Cross"),wxCROSS_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Horizontal line"),wxHORIZONTAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Vertical line"),wxVERTICAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Dotted-dashed line"),wxDOT_DASH));
-		arrayToFeed.Add(t_LstEnums(_("Small dash"),wxSHORT_DASH));
-		arrayToFeed.Add(t_LstEnums(_("Long dash"),wxLONG_DASH));
+		arrayToFeed.Add(t_LstEnums(_("Transparent"),wxPENSTYLE_TRANSPARENT));
+		arrayToFeed.Add(t_LstEnums(_("Continuous line"), wxPENSTYLE_SOLID));
+		arrayToFeed.Add(t_LstEnums(_("Point"), wxPENSTYLE_DOT));
+		arrayToFeed.Add(t_LstEnums(_("Left diagonal dash"), wxPENSTYLE_BDIAGONAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Cross"), wxPENSTYLE_CROSS_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Horizontal line"), wxPENSTYLE_HORIZONTAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Vertical line"), wxPENSTYLE_VERTICAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Dotted-dashed line"), wxPENSTYLE_DOT_DASH));
+		arrayToFeed.Add(t_LstEnums(_("Small dash"), wxPENSTYLE_SHORT_DASH));
+		arrayToFeed.Add(t_LstEnums(_("Long dash"), wxPENSTYLE_LONG_DASH));
 	}
 	void SG_EnumeratorFiller::FillBrushStyleEnumeration(StyleArray& arrayToFeed)
 	{
-		arrayToFeed.Add(t_LstEnums(_("Transparent"),wxTRANSPARENT));
-		arrayToFeed.Add(t_LstEnums(_("Full"),wxSOLID));
-		arrayToFeed.Add(t_LstEnums(_("Left diagonal dash"),wxBDIAGONAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Cross"),wxCROSSDIAG_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Right diagonal dash"),wxFDIAGONAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Plus"),wxCROSS_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Horizontal line"),wxHORIZONTAL_HATCH));
-		arrayToFeed.Add(t_LstEnums(_("Vertical line"),wxVERTICAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Transparent"), wxBRUSHSTYLE_TRANSPARENT));
+		arrayToFeed.Add(t_LstEnums(_("Full"), wxBRUSHSTYLE_SOLID));
+		arrayToFeed.Add(t_LstEnums(_("Left diagonal dash"), wxBRUSHSTYLE_BDIAGONAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Cross"), wxBRUSHSTYLE_CROSSDIAG_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Right diagonal dash"), wxBRUSHSTYLE_FDIAGONAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Plus"), wxBRUSHSTYLE_CROSS_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Horizontal line"), wxBRUSHSTYLE_HORIZONTAL_HATCH));
+		arrayToFeed.Add(t_LstEnums(_("Vertical line"), wxBRUSHSTYLE_VERTICAL_HATCH));
 	}
 	void SG_EnumeratorFiller::FillMarkersStyleEnumeration(StyleArray& arrayToFeed)
 	{


### PR DESCRIPTION
Switches to using Swig from choco in appveyor build. Currently the 4.0.2 version is downloaded. According to documentation swig 4.0.1 introduced support for Python 3.8 which we are using.
Updates wxWidgets to 3.1.5 and fixes deprecation warnings for wxPen and wxBrush styles.

I have tested I-SIMPA with updated libraries for and have not encountered any issues.