### PR TITLE
Properties grid fixes

### DIFF
--- a/src/isimpa/IHM/ComboTreeCtrl.cpp
+++ b/src/isimpa/IHM/ComboTreeCtrl.cpp
@@ -64,7 +64,7 @@ wxSize ComboTreeCtrl::GetAdjustedSize( int minWidth,
                                     int WXUNUSED(prefHeight),
                                     int maxHeight )
     {
-        return wxSize(wxMax(200,minWidth),wxMin(125,maxHeight));
+        return wxSize(FromDIP(wxMax(200,minWidth)),FromDIP(wxMin(150,maxHeight)));
     }
 
 wxWindow *ComboTreeCtrl::GetControl() { return this; }

--- a/src/isimpa/IHM/PropGrid.cpp
+++ b/src/isimpa/IHM/PropGrid.cpp
@@ -74,6 +74,10 @@ PropGrid::PropGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wx
 	wxAcceleratorTable accel(2, entries);
 	this->SetAcceleratorTable(accel);
 	SetRowLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTRE);
+
+	// Bind events for automatic resizing of last column
+	GetGridWindow()->Bind(wxEVT_SIZE, &PropGrid::OnGridWindowSize, this);
+	Bind(wxEVT_GRID_COL_SIZE, &PropGrid::OnColHeaderSize, this);
 }
 
 void PropGrid::OnLostFocus( wxFocusEvent& ev)
@@ -307,4 +311,31 @@ void PropGrid::AutoSizeLibelle( int row )
     ForceRefresh();
 	*/
 	//AutoSizeRowLabelSize(row);
+}
+
+void PropGrid::OnGridWindowSize(wxSizeEvent& event)
+{
+	if (GetNumberCols() > 0)
+		AutoSizeLastCol();
+}
+
+void PropGrid::OnColHeaderSize(wxGridSizeEvent& event)
+{
+	if (GetNumberCols() > 0)
+		AutoSizeLastCol();
+}
+
+void PropGrid::AutoSizeLastCol()
+{
+	int colWidths = 0;
+
+	for (int i = 0; i < GetNumberCols() - 1; i++)
+		colWidths += GetColWidth(i);
+
+	int finalColWidth = GetGridWindow()->GetSize().x - colWidths;
+
+	if (finalColWidth > FromDIP(50))
+		SetColSize(GetNumberCols() - 1, finalColWidth);
+	else
+		SetColSize(GetNumberCols() - 1, FromDIP(50));
 }

--- a/src/isimpa/IHM/PropGrid.h
+++ b/src/isimpa/IHM/PropGrid.h
@@ -84,6 +84,11 @@ protected:
     DECLARE_EVENT_TABLE()
 	
 	bool allowPaste;
+
+	//Functions for automatic resizing of last column
+	void OnGridWindowSize(wxSizeEvent& event);
+	void OnColHeaderSize(wxGridSizeEvent& event);
+	void AutoSizeLastCol();
 public:
 	/**
 	 * Constructeur

--- a/src/isimpa/data_manager/customEditor/wxGridCellTreeEditor.cpp
+++ b/src/isimpa/data_manager/customEditor/wxGridCellTreeEditor.cpp
@@ -39,7 +39,7 @@
 wxGridCellTreeEditor::wxGridCellTreeEditor(Element* _rootItem,Element* _defaultSelection,const std::list<Element::ELEMENT_TYPE>& elementFilter)
 :wxGridCellEditor(),rootItem(_rootItem),currentSelection(_defaultSelection),currentFilters(elementFilter)
 {
-
+	
 }
 
 void wxGridCellTreeEditor::BeginEdit(int row, int col, wxGrid* grid)
@@ -59,7 +59,19 @@ void wxGridCellTreeEditor::BeginEdit(int row, int col, wxGrid* grid)
     Combo()->SetInsertionPointEnd();
     Combo()->SetFocus();
 
+	// Save currently edited cell and bind combo closeup with edit end handler
+	edited_row = row;
+	edited_col = col;
+	currentGrid = grid;
+	Combo()->Bind(wxEVT_COMBOBOX_CLOSEUP, &wxGridCellTreeEditor::onEndEdit, this);
 }
+
+void wxGridCellTreeEditor::onEndEdit(wxCommandEvent& event) {
+	this->EndEdit(edited_row, edited_col, currentGrid, "", &wxString());								// Apply changes 'locally'
+	wxPostEvent(Combo(), wxGridEvent(0, wxEVT_GRID_CELL_CHANGED, currentGrid, edited_row, edited_col)); //Post event so that e_data_tree action is triggered
+	event.Skip();
+}
+
 bool wxGridCellTreeEditor::EndEdit(int row, int col, const wxGrid* grid, const wxString& oldval, wxString *newval)
 {
 	ComboTreeCtrl* popupCtrlTree=dynamic_cast<ComboTreeCtrl*>( Combo()->GetPopupControl());
@@ -74,8 +86,10 @@ bool wxGridCellTreeEditor::EndEdit(int row, int col, const wxGrid* grid, const w
 		currentSelection=newSelection;
 		grid->GetTable()->SetValue(row, col, value);
 
+		Combo()->Unbind(wxEVT_COMBOBOX_CLOSEUP, &wxGridCellTreeEditor::onEndEdit, this); //Not sure if it is needed(?)
 		return true;
 	}else{
+		Combo()->Unbind(wxEVT_COMBOBOX_CLOSEUP, &wxGridCellTreeEditor::onEndEdit, this);
 		return false;
 	}
 }
@@ -144,5 +158,5 @@ void wxGridCellTreeEditor::Reset(void)
 
 wxString wxGridCellTreeEditor::GetValue() const
 {
-  return Combo()->GetValue();
+	return Combo()->GetValue();
 }

--- a/src/isimpa/data_manager/customEditor/wxGridCellTreeEditor.h
+++ b/src/isimpa/data_manager/customEditor/wxGridCellTreeEditor.h
@@ -71,6 +71,12 @@ public:
 	 * @param grid Pointeur vers le contrôle
 	 */
     virtual void BeginEdit(int row, int col, wxGrid* grid);
+
+	/**
+	 * Event handler for cell edit end. Called when combobox is closed to automatically apply changes.
+	 */
+	void onEndEdit(wxCommandEvent& event);
+
 	/**
 	 * Fin d'édition du champ
 	 * @param row Ligne
@@ -90,6 +96,8 @@ public:
 	ComboTreeCtrl* GetTree();
 protected:
     wxGenericComboCtrl *Combo() const { return (wxGenericComboCtrl *)m_control; }
+	int edited_row, edited_col;
+	wxGrid* currentGrid;
 	Element *rootItem;
 	Element *currentSelection;
 	std::list<Element::ELEMENT_TYPE> currentFilters;


### PR DESCRIPTION
**Automatically resize last column of properties grid to fill window**
This simplifies changing parameters as the column is larger. Especially useful for assigning materials where the grid box was to small to see whole tree. The implementation is based on: https://forums.wxwidgets.org/viewtopic.php?t=41045

**Automatically apply changes made to e_data_tree properties**
Automatically  applies changes made to e_data_tree properties (assigning materials or directivities). Without modifications the changes are applied after second click on the parameter box. The solution may be a bit hacky, but everything else I tried was not working.